### PR TITLE
Remove deprecated tsconfig settings

### DIFF
--- a/src/frontend/tests/mockApi/auth/auth.handlers.ts
+++ b/src/frontend/tests/mockApi/auth/auth.handlers.ts
@@ -1,6 +1,6 @@
 import { http, type HttpHandler, HttpResponse } from 'msw';
+import { type GetAuthStatusResponse } from '@/features/auth';
 import { API_URL } from '@/shared/config';
-import { type GetAuthStatusResponse } from 'src/features/auth';
 import { usersService } from '../user';
 
 export const handlers: HttpHandler[] = [

--- a/src/frontend/tests/mockApi/categories/categories.handlers.ts
+++ b/src/frontend/tests/mockApi/categories/categories.handlers.ts
@@ -1,8 +1,8 @@
 import { http, type HttpHandler, type PathParams } from 'msw';
 import { type categoryModel } from '@/entities/category';
+import { type CategoryFormData } from '@/features/categories';
 import { API_URL } from '@/shared/config';
 import { type SelectOption } from '@/shared/types';
-import { type CategoryFormData } from 'src/features/categories';
 import { DelayedHttpResponse } from '../DelayedHttpResponse';
 import * as categoriesService from './categories.service';
 

--- a/src/frontend/tests/mockApi/categories/categories.service.ts
+++ b/src/frontend/tests/mockApi/categories/categories.service.ts
@@ -1,4 +1,4 @@
-import { type CategoryFormData } from 'src/features/categories';
+import { type CategoryFormData } from '@/features/categories';
 import { type DbCategory, db } from '../db';
 
 export const getAll = (): DbCategory[] =>

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -14,17 +14,23 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
-    "types": ["vitest/globals","vite-plugin-pwa/client"],
+    "types": [
+      "vitest/globals",
+      "vite-plugin-pwa/client"
+    ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@tests/*": ["./tests/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@tests/*": [
+        "./tests/*"
+      ]
     },
   },
   "include": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript project settings for more consistent module resolution and path handling.
  * Standardized internal import paths used by frontend test mocks and helpers.
  * No user-facing behavior, API responses, or test scenarios were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->