### PR TITLE
Add draft-release-changelog skill

### DIFF
--- a/.claude/skills/draft-release-changelog/SKILL.md
+++ b/.claude/skills/draft-release-changelog/SKILL.md
@@ -60,7 +60,9 @@ consistent with existing `CHANGELOG.md` entries.
   flag it in the reasoning but still propose a minor bump; leave the 1.0
   decision to the user.
 
-Compute `X.Y.Z` from the latest tag accordingly.
+Compute `X.Y.Z` from the latest tag accordingly. Strip the `v` prefix from the
+tag (e.g. `v0.5.0` → next `0.6.0`); the CHANGELOG heading and the version you
+report never carry the `v`.
 
 ### 5. Generate a descriptive title
 
@@ -86,7 +88,7 @@ approves.**
 
 ```shell
 git add CHANGELOG.md
-git commit -m "Prepare release X.Y.Z"
+git commit -m "$(printf 'Prepare release X.Y.Z\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
 ```
 
 ### 8. Report remaining manual steps

--- a/.claude/skills/draft-release-changelog/SKILL.md
+++ b/.claude/skills/draft-release-changelog/SKILL.md
@@ -84,11 +84,15 @@ approves.**
   generated content — never discard them.
 - Keep the heading regex-compatible with `.github/workflows/release.yml`
   (`^## \[X.Y.Z\]`).
-- Commit `CHANGELOG.md` only (do **not** push):
+- Commit `CHANGELOG.md` only (do **not** push). End the commit message with a
+  `Co-Authored-By` trailer naming the model you are **currently** running as
+  (read it from your own environment / system context) — do not hardcode a
+  model name:
 
 ```shell
+# Replace <current-model> with the model you are running as, e.g. "Claude Opus 4.8"
 git add CHANGELOG.md
-git commit -m "$(printf 'Prepare release X.Y.Z\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+git commit -m "$(printf 'Prepare release X.Y.Z\n\nCo-Authored-By: <current-model> <noreply@anthropic.com>')"
 ```
 
 ### 8. Report remaining manual steps

--- a/.claude/skills/draft-release-changelog/SKILL.md
+++ b/.claude/skills/draft-release-changelog/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: draft-release-changelog
+description: Use when preparing a new release of Food Diary - drafts the next CHANGELOG.md version entry from commits since the latest git tag and auto-determines the major/minor/patch bump
+---
+
+# Draft Release Changelog
+
+## Overview
+
+Automates step 1 of the README "Releasing" process. Reads the commits made
+since the latest `vX.Y.Z` tag, drafts a Keep a Changelog entry (Added /
+Changed / Fixed), determines the next version using pre-1.0 SemVer rules, and
+on approval edits `CHANGELOG.md` and commits (without pushing). Remaining
+release steps (push, dispatch the Release workflow) stay manual.
+
+## Workflow
+
+### 1. Preconditions
+
+- Resolve the latest release tag: `git describe --tags --abbrev=0` (e.g. `v0.5.0`).
+- If the current branch is not `main`, warn the user (releases are cut from
+  `main`) but allow continuing.
+- If there are no new commits, stop — nothing to release:
+
+```shell
+git rev-list "$(git describe --tags --abbrev=0)"..HEAD --count
+```
+
+If this prints `0`, stop.
+
+### 2. Gather changes
+
+```shell
+TAG=$(git describe --tags --abbrev=0)
+git log "$TAG"..HEAD --oneline      # commit list
+git log "$TAG"..HEAD -p             # diffs, for semantic understanding
+```
+
+Commits are **not** conventional-commit formatted — classify by reading the
+actual changes, not by parsing message prefixes.
+
+### 3. Classify changes (semantic analysis)
+
+Sort **user-facing** changes into Keep a Changelog buckets:
+
+- **Added** — new features / capabilities.
+- **Changed** — changes to existing behavior.
+- **Fixed** — bug fixes.
+- **Removed / Deprecated / Security** — only when applicable.
+
+Filter out non-user-facing noise (build/CI tweaks, internal design specs,
+editor-ignore commits, no-op refactors). Write concise, user-oriented bullets
+consistent with existing `CHANGELOG.md` entries.
+
+### 4. Determine the version bump (pre-1.0 aware)
+
+- Any entry in **Added** (new feature) → **minor** bump.
+- Only **Fixed** / **Changed** (no Added) → **patch** bump.
+- Never auto-select **major** while on `0.x`. If a breaking change is detected,
+  flag it in the reasoning but still propose a minor bump; leave the 1.0
+  decision to the user.
+
+Compute `X.Y.Z` from the latest tag accordingly.
+
+### 5. Generate a descriptive title
+
+A short phrase summarizing the release, matching existing entries
+(e.g. `AI nutrition suggestions on product form`).
+
+### 6. Present the draft for approval
+
+Show: proposed version `X.Y.Z` + title, the drafted Added / Changed / Fixed
+sections, and one-line bump reasoning. **Do not modify any files until the user
+approves.**
+
+### 7. On approval: edit CHANGELOG.md and commit (no push)
+
+- Rename the existing `## [Unreleased]` heading to `## [X.Y.Z] - <title>` and
+  fill it with the drafted content.
+- Insert a fresh empty `## [Unreleased]` section above it.
+- If `[Unreleased]` already contains manual entries, **merge** them with the
+  generated content — never discard them.
+- Keep the heading regex-compatible with `.github/workflows/release.yml`
+  (`^## \[X.Y.Z\]`).
+- Commit `CHANGELOG.md` only (do **not** push):
+
+```shell
+git add CHANGELOG.md
+git commit -m "Prepare release X.Y.Z"
+```
+
+### 8. Report remaining manual steps
+
+Remind the user what is left, per README "Releasing":
+
+1. Push `main`.
+2. Dispatch **Actions → Release → Run workflow** with the version (no `v` prefix).
+
+## Edge cases
+
+| Situation | Behavior |
+| --- | --- |
+| Not on `main` | Warn, allow continue |
+| No commits since latest tag | Stop — nothing to release |
+| `[Unreleased]` already has manual entries | Merge, never overwrite |
+| Breaking change detected on `0.x` | Flag in reasoning, still propose minor |
+| Heading format | Always `## [X.Y.Z] - <title>`, regex-compatible with release workflow |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !tests/.env
 *.code-workspace
 .claude/worktrees/
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -211,9 +211,14 @@ Releases are published to [Docker Hub](https://hub.docker.com/r/pkirilin/food-di
 
 To cut a new release:
 
-1. On `main`, update `CHANGELOG.md`:
-   - Rename the `[Unreleased]` section to `[X.Y.Z] - YYYY-MM-DD` (e.g. `[0.4.0] - 2026-05-09`).
-   - Add a fresh empty `[Unreleased]` section above it.
+1. On `main`, update `CHANGELOG.md`. Either:
+   - **(a) Manually:** rename the `[Unreleased]` section to
+     `[X.Y.Z] - <short descriptive title>`
+     (e.g. `[0.5.0] - Node.js 24 & minor packages bump`), and add a fresh empty
+     `[Unreleased]` section above it.
+   - **(b) With Claude Code:** run the `draft-release-changelog` skill, which
+     drafts the entry from commits since the latest tag, auto-determines the
+     version bump, and commits the change for you.
 2. Commit and push.
 3. Go to **Actions → Release → Run workflow**.
 4. Enter the version (e.g. `0.4.0`, no `v` prefix) and run.

--- a/docs/superpowers/plans/2026-07-11-draft-release-changelog-skill.md
+++ b/docs/superpowers/plans/2026-07-11-draft-release-changelog-skill.md
@@ -1,0 +1,260 @@
+# draft-release-changelog Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a project-level `draft-release-changelog` skill that drafts the next `CHANGELOG.md` release entry from commits since the latest tag and auto-determines the version bump, plus update README "Releasing" step 1 to document it.
+
+**Architecture:** A single `SKILL.md` instruction file (no code) that guides Claude through: discover latest tag → gather + semantically classify commits → determine pre-1.0 bump → draft entry → on approval edit `CHANGELOG.md` and commit (no push). A one-time README doc edit adds this as an alternative to manual editing and fixes the heading-format discrepancy. Validation is behavioral: dry-run the skill's git-discovery commands against the current repo and confirm the values it would derive.
+
+**Tech Stack:** Markdown skill file with YAML frontmatter; git CLI (`git describe`, `git log`, `git rev-list`); Keep a Changelog + SemVer conventions.
+
+## Global Constraints
+
+- Skill lives at `.claude/skills/draft-release-changelog/SKILL.md` (project-level, committed).
+- Frontmatter must have `name` and `description` fields (match existing repo skills like `pk-self-improving`).
+- Version headings must stay compatible with the release workflow extractor regex `^## \[X.Y.Z\]` (see `.github/workflows/release.yml:47-52`).
+- Heading format is always `## [X.Y.Z] - <descriptive title>` (never a date).
+- Project is pre-1.0 (`0.x`): features/breaking → minor, fixes/chores only → patch, never auto-select major.
+- Skill runtime touches **only** `CHANGELOG.md`; it must not edit README on each run.
+- Follow project comment/naming rules in `.claude/rules/coding.md`.
+- Commits end with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: Author the SKILL.md
+
+**Files:**
+- Create: `.claude/skills/draft-release-changelog/SKILL.md`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: the skill file. Later tasks and the README reference the skill by its `name:` slug `draft-release-changelog`.
+
+Because this is an instruction file (not code), the "test" is a review of required sections against the spec, plus a dry-run of the git-discovery commands in Task 3.
+
+- [ ] **Step 1: Recommended — invoke the skill-authoring sub-skill**
+
+Optionally invoke `superpowers:writing-skills` for authoring conventions (frontmatter, structure, verification). If unavailable, follow the structure of the existing `~/.claude/skills/pk-self-improving/SKILL.md` (frontmatter + `## Overview` + `## Workflow` with numbered steps + `## Edge cases` table).
+
+- [ ] **Step 2: Write the frontmatter and overview**
+
+Create `.claude/skills/draft-release-changelog/SKILL.md` starting with:
+
+```markdown
+---
+name: draft-release-changelog
+description: Use when preparing a new release of Food Diary - drafts the next CHANGELOG.md version entry from commits since the latest git tag and auto-determines the major/minor/patch bump
+---
+
+# Draft Release Changelog
+
+## Overview
+
+Automates step 1 of the README "Releasing" process. Reads the commits made
+since the latest `vX.Y.Z` tag, drafts a Keep a Changelog entry (Added /
+Changed / Fixed), determines the next version using pre-1.0 SemVer rules, and
+on approval edits `CHANGELOG.md` and commits (without pushing). Remaining
+release steps (push, dispatch the Release workflow) stay manual.
+```
+
+- [ ] **Step 3: Write the Workflow section**
+
+Append the 8-step workflow. Copy the exact commands so the executing engineer needs no other reference:
+
+````markdown
+## Workflow
+
+### 1. Preconditions
+
+- Resolve the latest release tag: `git describe --tags --abbrev=0` (e.g. `v0.5.0`).
+- If the current branch is not `main`, warn the user (releases are cut from
+  `main`) but allow continuing.
+- If there are no new commits, stop — nothing to release:
+
+```shell
+git rev-list "$(git describe --tags --abbrev=0)"..HEAD --count
+```
+
+If this prints `0`, stop.
+
+### 2. Gather changes
+
+```shell
+TAG=$(git describe --tags --abbrev=0)
+git log "$TAG"..HEAD --oneline      # commit list
+git log "$TAG"..HEAD -p             # diffs, for semantic understanding
+```
+
+Commits are **not** conventional-commit formatted — classify by reading the
+actual changes, not by parsing message prefixes.
+
+### 3. Classify changes (semantic analysis)
+
+Sort **user-facing** changes into Keep a Changelog buckets:
+
+- **Added** — new features / capabilities.
+- **Changed** — changes to existing behavior.
+- **Fixed** — bug fixes.
+- **Removed / Deprecated / Security** — only when applicable.
+
+Filter out non-user-facing noise (build/CI tweaks, internal design specs,
+editor-ignore commits, no-op refactors). Write concise, user-oriented bullets
+consistent with existing `CHANGELOG.md` entries.
+
+### 4. Determine the version bump (pre-1.0 aware)
+
+- Any entry in **Added** (new feature) → **minor** bump.
+- Only **Fixed** / **Changed** (no Added) → **patch** bump.
+- Never auto-select **major** while on `0.x`. If a breaking change is detected,
+  flag it in the reasoning but still propose a minor bump; leave the 1.0
+  decision to the user.
+
+Compute `X.Y.Z` from the latest tag accordingly.
+
+### 5. Generate a descriptive title
+
+A short phrase summarizing the release, matching existing entries
+(e.g. `AI nutrition suggestions on product form`).
+
+### 6. Present the draft for approval
+
+Show: proposed version `X.Y.Z` + title, the drafted Added / Changed / Fixed
+sections, and one-line bump reasoning. **Do not modify any files until the user
+approves.**
+
+### 7. On approval: edit CHANGELOG.md and commit (no push)
+
+- Rename the existing `## [Unreleased]` heading to `## [X.Y.Z] - <title>` and
+  fill it with the drafted content.
+- Insert a fresh empty `## [Unreleased]` section above it.
+- If `[Unreleased]` already contains manual entries, **merge** them with the
+  generated content — never discard them.
+- Keep the heading regex-compatible with `.github/workflows/release.yml`
+  (`^## \[X.Y.Z\]`).
+- Commit `CHANGELOG.md` only (do **not** push):
+
+```shell
+git add CHANGELOG.md
+git commit -m "Prepare release X.Y.Z"
+```
+
+### 8. Report remaining manual steps
+
+Remind the user what is left, per README "Releasing":
+
+1. Push `main`.
+2. Dispatch **Actions → Release → Run workflow** with the version (no `v` prefix).
+
+## Edge cases
+
+| Situation | Behavior |
+| --- | --- |
+| Not on `main` | Warn, allow continue |
+| No commits since latest tag | Stop — nothing to release |
+| `[Unreleased]` already has manual entries | Merge, never overwrite |
+| Breaking change detected on `0.x` | Flag in reasoning, still propose minor |
+| Heading format | Always `## [X.Y.Z] - <title>`, regex-compatible with release workflow |
+````
+
+- [ ] **Step 4: Verify required sections are present**
+
+Run:
+
+```shell
+rg -n "^(name:|description:|## Overview|### 1\.|### 4\.|### 7\.|## Edge cases)" .claude/skills/draft-release-changelog/SKILL.md
+```
+
+Expected: matches for the frontmatter fields, Overview, workflow steps 1/4/7, and Edge cases — confirming the file is structurally complete.
+
+- [ ] **Step 5: Commit**
+
+```shell
+git add .claude/skills/draft-release-changelog/SKILL.md
+git commit -m "$(printf 'Add draft-release-changelog skill\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 2: Update README "Releasing" step 1
+
+**Files:**
+- Modify: `README.md:214-216` (the "Releasing" step 1 bullet)
+
+**Interfaces:**
+- Consumes: the skill `name` slug `draft-release-changelog` from Task 1.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Replace step 1 with two options**
+
+In `README.md`, replace the current step 1:
+
+```markdown
+1. On `main`, update `CHANGELOG.md`:
+   - Rename the `[Unreleased]` section to `[X.Y.Z] - YYYY-MM-DD` (e.g. `[0.4.0] - 2026-05-09`).
+   - Add a fresh empty `[Unreleased]` section above it.
+```
+
+with:
+
+```markdown
+1. On `main`, update `CHANGELOG.md`. Either:
+   - **(a) Manually:** rename the `[Unreleased]` section to
+     `[X.Y.Z] - <short descriptive title>`
+     (e.g. `[0.5.0] - Node.js 24 & minor packages bump`), and add a fresh empty
+     `[Unreleased]` section above it.
+   - **(b) With Claude Code:** run the `draft-release-changelog` skill, which
+     drafts the entry from commits since the latest tag, auto-determines the
+     version bump, and commits the change for you.
+```
+
+- [ ] **Step 2: Verify heading-format correction and skill reference**
+
+Run:
+
+```shell
+rg -n "draft-release-changelog|short descriptive title|YYYY-MM-DD" README.md
+```
+
+Expected: the skill reference and the "short descriptive title" phrasing are present under "Releasing", and the old `YYYY-MM-DD` form no longer appears in step 1.
+
+- [ ] **Step 3: Commit**
+
+```shell
+git add README.md
+git commit -m "$(printf 'Document draft-release-changelog skill in README release steps\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: Behavioral dry-run against the current repo
+
+**Files:**
+- None (validation only).
+
+**Interfaces:**
+- Consumes: the workflow commands authored in Task 1.
+- Produces: confidence that the skill derives correct values; no artifacts.
+
+This confirms the skill's discovery logic yields the expected release for the repo's current state (7 commits since `v0.5.0`, headlined by the AI nutrition suggestions feature → `0.6.0`).
+
+- [ ] **Step 1: Run the discovery commands**
+
+```shell
+git describe --tags --abbrev=0
+git rev-list "$(git describe --tags --abbrev=0)"..HEAD --count
+git log "$(git describe --tags --abbrev=0)"..HEAD --oneline
+```
+
+Expected: tag `v0.5.0`; a non-zero count; a commit list including the AI nutrition suggestions feature.
+
+- [ ] **Step 2: Confirm the derived version**
+
+Apply the Task 1 step-4 bump rule to the classified commits by hand: a new user-facing feature is present → minor bump → next version `0.6.0`. Confirm this matches the spec's stated expectation. No commit — validation only.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Preconditions (§1), gather (§2), classify (§3), bump (§4), title (§5), approval (§6), edit+commit (§7), report (§8) → Task 1. README two-options + heading fix (build-time deliverable) → Task 2. Expected `0.6.0` outcome → Task 3. All spec sections covered.
+- **Placeholder scan:** No TBD/TODO; all steps carry concrete commands and file content.
+- **Type consistency:** Skill slug `draft-release-changelog` used identically in the frontmatter (Task 1), README reference (Task 2), and validation (Task 3). Heading format `## [X.Y.Z] - <title>` consistent across all tasks and the Global Constraints.

--- a/docs/superpowers/specs/2026-07-11-draft-release-changelog-skill-design.md
+++ b/docs/superpowers/specs/2026-07-11-draft-release-changelog-skill-design.md
@@ -1,0 +1,127 @@
+# Design: `draft-release-changelog` skill
+
+## Goal
+
+Automate step 1 of the README "Releasing" process: draft the `CHANGELOG.md`
+entry for the next release from the commits made since the latest git tag, and
+automatically determine the new version bump (major / minor / patch).
+
+## Location
+
+Project-level skill, committed to the repo:
+
+```
+.claude/skills/draft-release-changelog/SKILL.md
+```
+
+## Inputs / assumptions
+
+- Latest release tag follows `vX.Y.Z` (current latest: `v0.5.0`).
+- `CHANGELOG.md` uses the Keep a Changelog format with an `[Unreleased]`
+  section at the top and per-version headings of the form
+  `## [X.Y.Z] - <descriptive title>` (the actual convention in this repo;
+  README currently documents a date form, which this skill corrects).
+- The Release GitHub Actions workflow extracts notes by matching
+  `^## \[X.Y.Z\]` — any heading this skill produces must stay compatible.
+- Project is pre-1.0 (`0.x`).
+
+## Workflow
+
+### 1. Find the latest tag and preconditions
+
+- Resolve latest tag: `git describe --tags --abbrev=0` (e.g. `v0.5.0`).
+- If the current branch is not `main`, warn the user (releases are cut from
+  `main`) but allow continuing.
+- If there are no commits since the tag (`git rev-list <tag>..HEAD --count` is
+  `0`), stop — nothing to release.
+
+### 2. Gather changes
+
+- `git log <tag>..HEAD --oneline` for the commit list.
+- Inspect diffs (`git log <tag>..HEAD -p` / `git diff <tag>..HEAD`) as needed
+  to understand the nature of each change semantically. Commits in this repo are
+  **not** conventional-commit formatted, so classification is based on reading
+  the changes, not parsing prefixes.
+
+### 3. Classify changes (semantic analysis)
+
+Sort **user-facing** changes into Keep a Changelog buckets:
+
+- **Added** — new features / capabilities.
+- **Changed** — changes to existing behavior.
+- **Fixed** — bug fixes.
+- **Removed / Deprecated / Security** — include only when applicable.
+
+Filter out non-user-facing noise (build tooling, CI tweaks, internal design
+specs, editor-ignore commits, refactors with no observable effect) instead of
+dumping every commit. Entries are written as concise, user-oriented bullet
+points consistent with existing CHANGELOG style.
+
+### 4. Determine the version bump (pre-1.0 aware)
+
+Based on the classified changes:
+
+- Any new feature (entries in **Added**) → **minor** bump.
+- Only fixes / changes (no **Added**) → **patch** bump.
+- **major** is never auto-selected while on `0.x` (reserved for a deliberate
+  `1.0`). If a breaking change is detected, the skill flags it in the reasoning
+  and still proposes a minor bump per pre-1.0 SemVer convention, leaving the
+  1.0 decision to the user.
+
+Compute `X.Y.Z` from the latest tag accordingly.
+
+> For the repo's current state (7 commits since `v0.5.0`, headlined by the AI
+> nutrition suggestions feature), this yields **0.6.0**.
+
+### 5. Generate a descriptive title
+
+A short phrase summarizing the release, matching existing entries
+(e.g. `AI nutrition suggestions on product form`).
+
+### 6. Present the draft for approval
+
+Show the user:
+
+- Proposed version `X.Y.Z` and title.
+- The drafted Added / Changed / Fixed sections.
+- One-line reasoning for the chosen bump.
+
+Do not modify any files until the user approves.
+
+### 7. On approval: edit files and commit (no push)
+
+- **`CHANGELOG.md`**: rename the existing `[Unreleased]` heading to
+  `## [X.Y.Z] - <title>`, fill it with the drafted content, and insert a fresh
+  empty `## [Unreleased]` section above it. If `[Unreleased]` already contains
+  manually-written entries, **merge** them with the generated content — never
+  discard them.
+- **`README.md` step 1**: rewrite the "Releasing" step 1 to present two options:
+  - **(a)** manual CHANGELOG editing (the existing instructions, corrected to
+    the `## [X.Y.Z] - <descriptive title>` heading format).
+  - **(b)** using this `draft-release-changelog` skill.
+- **Commit** both files (do **not** push). Commit message summarizes the
+  release preparation (e.g. `Prepare release 0.6.0`).
+
+### 8. Report remaining manual steps
+
+After committing, remind the user of what is left, per README:
+
+1. Push `main`.
+2. Dispatch **Actions → Release → Run workflow** with the version (no `v`
+   prefix).
+
+## Edge cases
+
+| Situation | Behavior |
+| --- | --- |
+| Not on `main` | Warn, allow continue |
+| No commits since latest tag | Stop — nothing to release |
+| `[Unreleased]` already has manual entries | Merge, never overwrite |
+| Breaking change detected on `0.x` | Flag in reasoning, still propose minor |
+| Heading format | Always `## [X.Y.Z] - <title>`, regex-compatible with release workflow |
+
+## Out of scope
+
+- Pushing the branch or dispatching the Release workflow (remain manual).
+- Building/publishing Docker images or creating the git tag (handled by the
+  Release workflow).

--- a/docs/superpowers/specs/2026-07-11-draft-release-changelog-skill-design.md
+++ b/docs/superpowers/specs/2026-07-11-draft-release-changelog-skill-design.md
@@ -88,19 +88,29 @@ Show the user:
 
 Do not modify any files until the user approves.
 
-### 7. On approval: edit files and commit (no push)
+### 7. On approval: edit CHANGELOG and commit (no push)
 
 - **`CHANGELOG.md`**: rename the existing `[Unreleased]` heading to
   `## [X.Y.Z] - <title>`, fill it with the drafted content, and insert a fresh
   empty `## [Unreleased]` section above it. If `[Unreleased]` already contains
   manually-written entries, **merge** them with the generated content — never
   discard them.
-- **`README.md` step 1**: rewrite the "Releasing" step 1 to present two options:
-  - **(a)** manual CHANGELOG editing (the existing instructions, corrected to
-    the `## [X.Y.Z] - <descriptive title>` heading format).
-  - **(b)** using this `draft-release-changelog` skill.
-- **Commit** both files (do **not** push). Commit message summarizes the
+- **Commit** `CHANGELOG.md` (do **not** push). Commit message summarizes the
   release preparation (e.g. `Prepare release 0.6.0`).
+
+> The skill's runtime behavior touches **only** `CHANGELOG.md`. The README
+> documentation change below is a **one-time build task** performed while
+> creating the skill, not something the skill re-does on every release.
+
+## Build-time deliverable: README "Releasing" step 1
+
+As part of shipping this skill, rewrite README "Releasing" step 1 to present
+two options and correct the documented heading format:
+
+- **(a)** Manual CHANGELOG editing — the existing instructions, corrected from
+  `[X.Y.Z] - YYYY-MM-DD` to the actual `## [X.Y.Z] - <descriptive title>`
+  heading format.
+- **(b)** Using the `draft-release-changelog` skill to draft it automatically.
 
 ### 8. Report remaining manual steps
 


### PR DESCRIPTION
## Summary

Adds a project-level Claude Code skill, `draft-release-changelog`, that automates step 1 of the README "Releasing" process: it drafts the next `CHANGELOG.md` version entry from the commits made since the latest `vX.Y.Z` tag and automatically determines the major/minor/patch bump.

## What it does (skill runtime)

- Resolves the latest tag (`git describe --tags --abbrev=0`); warns off `main`, stops if there are no new commits.
- Reads and **semantically classifies** commits (they aren't conventional-commit formatted) into Keep a Changelog buckets — Added / Changed / Fixed — filtering out non-user-facing noise.
- Determines the bump with **pre-1.0 SemVer** rules: any new feature → minor; only fixes/changes → patch; never auto-selects major on `0.x`.
- Presents the draft for approval, then edits **only** `CHANGELOG.md` (rename `[Unreleased]` → `## [X.Y.Z] - <descriptive title>`, insert a fresh empty `[Unreleased]`, merge any existing entries) and commits **without** pushing.
- Heading stays compatible with the Release workflow extractor regex (`^## \[X.Y.Z\]`).

## Other changes

- **README "Releasing" step 1** now offers two options — (a) manual editing, (b) the skill — and corrects the documented heading format from `[X.Y.Z] - YYYY-MM-DD` to the descriptive-title form actually used in every CHANGELOG entry.
- Design spec + implementation plan under `docs/superpowers/`.
- `.gitignore`: ignore `.superpowers/` scratch.

## Process

Built via brainstorm → spec → plan → subagent-driven execution (per-task reviews + an Opus whole-branch review, verdict: ready to merge). For the repo's current state, the skill would propose **0.6.0** (AI nutrition suggestions feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a release-assistance workflow that drafts changelog entries from recent commits.
  * Includes version-bump recommendations, release titles, change classification, and approval before edits.
  * Supports preserving existing unreleased notes and preparing the changelog for release.

* **Documentation**
  * Updated release instructions with manual and assisted changelog preparation options.
  * Added supporting documentation describing the workflow, validation steps, and edge cases.

* **Chores**
  * Added an ignore rule for generated release-assistance files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->