### PR TITLE
Fix excessive Read permission prompts; scope env deny rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,8 +31,10 @@
       "Read(./**)"
     ],
     "deny": [
-      "Read(./**/.env)",
-      "Read(./**/.env.local)",
+      "Read(./.env)",
+      "Read(./src/**/.env)",
+      "Read(./src/frontend/**/.env.local)",
+      "Read(./src/frontend/**/.env.*.local)",
       "Read(./secrets/**)"
     ],
     "ask": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,8 +28,7 @@
       "Bash(dotnet test:*)",
       "Bash(unzip -p:*)",
       "Bash(npm view:*)",
-      "Read(./.superpowers/**)",
-      "Read(./src/**)"
+      "Read(./**)"
     ],
     "deny": [
       "Read(./**/.env)",
@@ -39,7 +38,6 @@
     "ask": [
       "Bash(curl:*)",
       "Bash(rm:*)",
-      "Read(~/**)",
       "Bash(git push:*)",
       "mcp__github_com_github_github-mcp-server__get_me",
       "mcp__github_com_github_github-mcp-server__pull_request_read",


### PR DESCRIPTION
## Summary

Fixes constant Read permission prompts for in-project files (`./src/**`, `./.superpowers/**`, project root) that persisted even in auto/accept-edits mode, and tightens the `.env` deny rules toward the project's gitignore set.

## Root cause

`.claude/settings.json` had `Read(~/**)` in the `ask` list. Because the project lives under `$HOME`, that rule matched **every** file in the project, and since rule precedence is `deny` → `ask` → `allow`, it overrode all the explicit in-project `Read(...)` allow rules — forcing a prompt on every read. Permission modes (`acceptEdits`/auto) only auto-accept *edits*, never `ask` rules, so the prompts never stopped.

## Changes

- **Remove `Read(~/**)` from `ask`** — the root cause.
- **Collapse per-path read allows into a single `Read(./**)`** — covers the whole project (including directory entries the old `**`-suffixed globs missed).
- **Scope the `.env` deny rules** toward the gitignored env patterns: root `.env`, `src/**/.env`, and `src/frontend` `.env.local` / `.env.*.local`. `secrets/**` kept as a defensive extra.

## Known limitation (to be fixed in a follow-up branch)

The goal "deny **only** gitignored env files" is not fully achieved: `tests/.env` is tracked (git un-ignores it via `!tests/.env`), but Claude Code's deny matcher treats `Read(./.env)` as "any file named `.env` in any directory" and has no `!` negation — so `tests/.env` is still denied. Its tracked content is placeholder/fake test credentials, so the practical impact is nil, but the rule is broader than intended. Verification of this was deferred per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)