### PR TITLE
Widen changelog scope rules

### DIFF
--- a/.claude/skills/draft-release-changelog/SKILL.md
+++ b/.claude/skills/draft-release-changelog/SKILL.md
@@ -13,6 +13,9 @@ Changed / Fixed), determines the next version using pre-1.0 SemVer rules, and
 on approval edits `CHANGELOG.md` and commits (without pushing). Remaining
 release steps (push, dispatch the Release workflow) stay manual.
 
+Two approval gates: the user confirms which changes are in scope, then
+approves the finished draft before anything is written.
+
 ## Workflow
 
 ### 1. Preconditions
@@ -39,22 +42,61 @@ git log "$TAG"..HEAD -p             # diffs, for semantic understanding
 Commits are **not** conventional-commit formatted — classify by reading the
 actual changes, not by parsing message prefixes.
 
-### 3. Classify changes (semantic analysis)
+### 3. Identify the notable changes
 
-Sort **user-facing** changes into Keep a Changelog buckets:
+`CHANGELOG.md` documents **all notable changes**. A change is notable when it
+matters to **someone running or maintaining this app**, not only to someone
+using it. Runtime and dependency upgrades, Docker and deployment configuration,
+build and CI behavior, and security posture all clear that bar — existing
+entries cover .NET 10, yarn, `Dockerfile` `CMD`, and Node.js deprecation
+warnings, none of which are visible in the UI.
+
+Leave out only what a reader gains nothing from:
+
+- formatting-only commits
+- lockfile churn
+- documentation typos
+- no-op refactors
+- `.scratch/` specs
+- agent skills and `.claude/` config
+
+List one candidate per notable change, phrased as the changelog line it would
+become.
+
+### 4. Confirm the scope
+
+Put the candidates to the user through the **`AskUserQuestion` tool** — always
+that tool, so the answer is a click rather than typed-out numbers:
+
+- `multiSelect: true`, one option per candidate change.
+- Option `label` — the change in 1–5 words. Option `description` — the
+  changelog line it would become.
+- Pre-select nothing; the user's picks *are* the scope.
+
+The tool caps a question at 4 options. A release runs longer than a branch, so
+keep asking — across further questions and further calls — until every
+candidate has been offered; overflow never goes into the exclusion list. Title
+each question so the user can see the end coming ("Which changes belong in
+0.8.0? (2 of 3)").
+
+List what you left out as plain chat text beneath, so the user can see it and
+pull anything back via the tool's "Other" free-text field.
+
+**Stop and wait for the answer.**
+
+### 5. Sort the selected changes into buckets
 
 - **Added** — new features / capabilities.
 - **Changed** — changes to existing behavior.
 - **Fixed** — bug fixes.
 - **Removed / Deprecated / Security** — only when applicable.
 
-Filter out non-user-facing noise (build/CI tweaks, internal design specs,
-editor-ignore commits, no-op refactors). Write concise, user-oriented bullets
-consistent with existing `CHANGELOG.md` entries.
+Write concise bullets consistent with existing `CHANGELOG.md` entries: one
+line each, plain prose, no bold lead-ins.
 
-### 4. Determine the version bump (pre-1.0 aware)
+### 6. Determine the version bump (pre-1.0 aware)
 
-- Any entry in **Added** (new feature) → **minor** bump.
+- Any entry in **Added** → **minor** bump.
 - Only **Fixed** / **Changed** (no Added) → **patch** bump.
 - Never auto-select **major** while on `0.x`. If a breaking change is detected,
   flag it in the reasoning but still propose a minor bump; leave the 1.0
@@ -64,18 +106,18 @@ Compute `X.Y.Z` from the latest tag accordingly. Strip the `v` prefix from the
 tag (e.g. `v0.5.0` → next `0.6.0`); the CHANGELOG heading and the version you
 report never carry the `v`.
 
-### 5. Generate a descriptive title
+### 7. Generate a descriptive title
 
 A short phrase summarizing the release, matching existing entries
 (e.g. `AI nutrition suggestions on product form`).
 
-### 6. Present the draft for approval
+### 8. Present the draft for approval
 
 Show: proposed version `X.Y.Z` + title, the drafted Added / Changed / Fixed
 sections, and one-line bump reasoning. **Do not modify any files until the user
 approves.**
 
-### 7. On approval: edit CHANGELOG.md and commit (no push)
+### 9. On approval: edit CHANGELOG.md and commit (no push)
 
 - Rename the existing `## [Unreleased]` heading to `## [X.Y.Z] - <title>` and
   fill it with the drafted content.
@@ -95,7 +137,7 @@ git add CHANGELOG.md
 git commit -m "$(printf 'Prepare release X.Y.Z\n\nCo-Authored-By: <current-model> <noreply@anthropic.com>')"
 ```
 
-### 8. Report remaining manual steps
+### 10. Report remaining manual steps
 
 Remind the user what is left, per README "Releasing":
 
@@ -108,6 +150,8 @@ Remind the user what is left, per README "Releasing":
 | --- | --- |
 | Not on `main` | Warn, allow continue |
 | No commits since latest tag | Stop — nothing to release |
+| User selects no changes at the scope gate | Stop — nothing to release |
+| More than 4 candidate changes | Keep asking until every candidate is offered |
 | `[Unreleased]` already has manual entries | Merge, never overwrite |
 | Breaking change detected on `0.x` | Flag in reasoning, still propose minor |
 | Heading format | Always `## [X.Y.Z] - <title>`, regex-compatible with release workflow |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - React 19, MUI v9 & AI photo zoom
+
+### Added
+
+- Pan and zoom the suggested photo when adding a note via AI-based product recognition
+
+### Changed
+
+- Upgraded MUI from v6 to v9
+- Selecting a day in the date switcher now requires confirming with OK, due to the MUI v9 upgrade
+- Upgraded frontend to React 19
+- Migrated frontend lint tooling to ESLint 10's flat config format
+
 ## [0.7.0] - Deployment configuration changes
 
 ### Changed


### PR DESCRIPTION
The changelog skill's rule for what belongs in a release contradicted the changelog itself. It said to keep only "user-facing" changes and to filter out build and CI work, while `CHANGELOG.md` states that it records all notable changes — and past releases duly record .NET 10, yarn, and `Dockerfile` changes that are invisible in the UI. This brings the skill in line with what the file already does.

- **The bar is now whether a change matters to someone running or maintaining the app**, not only to someone using it. Runtime and dependency upgrades, deployment configuration, and CI behavior all qualify; formatting, lockfile churn, and no-op refactors still don't.
- **You choose what belongs in the release before the entry is drafted.** The skill used to settle the scope on its own and show you the finished entry, so anything it discarded took a rewrite to recover. It now asks first, making that one click.

:robot: Generated with AI
